### PR TITLE
Use flags to provide configuration values

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ go get github.com/zupzup/blog-generator
 Just execute
 
 ```bash
-blog-generator
+blog-generator -repo git@github.com:username/repo.git
 ```
 
 in this repository's root directory.
@@ -34,15 +34,25 @@ in this repository's root directory.
 
 ### Configure the CLI
 
-Set the following constants in `cli/cli.go`:
+Provide `flag` to binary. To know which flags are used and which are used and
+to override them:
 
-```go
-// data source for the blog
-const RepoURL string = "git@github.com:username/repo.git"
-// folder to download the repo into
-const TmpFolder string = "./tmp"
-// output folder
-const DestFolder string = "./www"
+```shell
+go build
+
+./blog-generator -h
+```
+
+Output:
+
+```
+Usage of ./blog-generator:
+  -destfolder string
+        is the output folder of the static blog (default "./www")
+  -repo string
+        Repository URL
+  -tmpfolder string
+        folder where the data-source repo is checked out to (default "./tmp")
 ```
 
 ### Configure the Generator

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,32 +1,29 @@
 package cli
 
 import (
+	"log"
+
+	"github.com/zupzup/blog-generator/config"
 	"github.com/zupzup/blog-generator/datasource"
 	"github.com/zupzup/blog-generator/generator"
-	"log"
 )
-
-// RepoURL is the URL of the data-source repository
-const RepoURL string = "git@github.com:zupzup/blog.git"
-
-// TmpFolder is the folder where the data-source repo is checked out to
-const TmpFolder string = "./tmp"
-
-// DestFolder is the output folder of the static blog
-const DestFolder string = "./www"
 
 // Run runs the application
 func Run() {
 	ds := datasource.New()
-	dirs, err := ds.Fetch(RepoURL, TmpFolder)
+	dirs, err := ds.Fetch(config.RepoURL, config.TmpFolder)
+
 	if err != nil {
 		log.Fatal(err)
 	}
+
 	g := generator.New(&generator.SiteConfig{
 		Sources:     dirs,
-		Destination: DestFolder,
+		Destination: config.DestFolder,
 	})
+
 	err = g.Generate()
+
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/config/init.go
+++ b/config/init.go
@@ -1,0 +1,10 @@
+package config
+
+// RepoURL is the URL of the data-source repository
+var RepoURL string
+
+// TmpFolder is the folder where the data-source repo is checked out to
+var TmpFolder string
+
+// DestFolder is the output folder of the static blog
+var DestFolder string

--- a/main.go
+++ b/main.go
@@ -1,9 +1,20 @@
 package main
 
 import (
+	"flag"
+
 	"github.com/zupzup/blog-generator/cli"
+	"github.com/zupzup/blog-generator/config"
 )
 
+func init() {
+	flag.StringVar(&config.RepoURL, "repo", "", "Repository URL")
+	flag.StringVar(&config.TmpFolder, "tmpfolder", "./tmp", "folder where the data-source repo is checked out to")
+	flag.StringVar(&config.DestFolder, "destfolder", "./www", "is the output folder of the static blog")
+}
+
 func main() {
+	// Get flags and set values to vars defined on init
+	flag.Parse()
 	cli.Run()
 }


### PR DESCRIPTION
I find flags a very useful option when providing configuration values to go binaries. And the ability to _ask_ to binary which options are available is wonderful.

Allow user specify config via flags:
	./blog-generator -repo git@github.com:username/repo.git

and request help to the binary by

```shell
./blog-generator -h
```

It will output:

```
Usage of ./blog-generator:
  -destfolder string
        is the output folder of the static blog (default "./www")
  -repo string
        Repository URL
  -tmpfolder string
        folder where the data-source repo is checked out to (default "./tmp")
```

No changes are required to exiting source code, just provide `-repo` flag