### PR TITLE
Add handling for starting local HTTP golang serve for development

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"path/filepath"
+	"net/http"
 
 	yaml "gopkg.in/yaml.v2"
 
@@ -36,6 +38,28 @@ func Run() {
 	if err != nil {
 		log.Fatal(err)
 	}
+}
+
+// Start a local HTTP server for development/testing purposes
+func Serve() {
+	cwd, cwdErr:= os.Getwd()
+
+	if cwdErr != nil {
+		log.Fatal(cwdErr)
+	}
+
+	staticPath := filepath.Join(cwd, "www")
+	log.Printf("Serving directory %s", staticPath)
+	log.Println("HTTP Server listening on 127.0.0.1:8000")
+	fileSystemDir := http.FileServer(http.Dir(staticPath))
+	http.Handle("/", fileSystemDir)
+
+	err := http.ListenAndServe(":8000", nil)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
 }
 
 func readConfig() (*config.Config, error) {

--- a/main.go
+++ b/main.go
@@ -1,9 +1,27 @@
 package main
 
 import (
+	"flag"
+	"fmt"
+	"os"
+
 	"github.com/zupzup/blog-generator/cli"
 )
 
 func main() {
-	cli.Run()
+	serveFlag := flag.Bool("s", false, "start a local HTTP server to view static files for local testing")
+
+	flag.Parse()
+
+	argNums := len(os.Args)
+
+	if argNums < 2 {
+		cli.Run()
+	} else {
+		if *serveFlag {
+			cli.Serve()
+		} else {
+			fmt.Println("Improper arguments")
+		}
+	}
 }


### PR DESCRIPTION
Added a flag `-s` to serve the local `www` folder with net/http in golang. This removes the need for the python `run.sh` SimpleHTTPServer.